### PR TITLE
Fetch all pages when fetching objecttypes

### DIFF
--- a/boom-app/src/views/PreView.vue
+++ b/boom-app/src/views/PreView.vue
@@ -168,16 +168,11 @@ function postSingleObject(typeUrl: string, version: number, properties: MappedRe
  * @param searchResults Search results returned from the server
  */
 function hasObject(mappedObject: MappedRecord, searchResults: ObjectData[]): boolean {
-  for (const existingObject of searchResults) {
-    let hasObject: boolean = true
-    for (const [property, value] of Object.entries(existingObject.record.data)) {
-      hasObject = mappedObject[property] !== undefined && value === mappedObject[property]
-    }
-    if (hasObject) {
-      return true
-    }
-  }
-  return false
+  return searchResults.some(existingObject =>
+    Object.entries(existingObject.record.data).every(([property, value]) =>
+      mappedObject[property] === value
+    )
+  )
 }
 
 /**

--- a/boom-app/src/views/PreView.vue
+++ b/boom-app/src/views/PreView.vue
@@ -218,15 +218,17 @@ function postSingleObject(typeUrl: string, version: number, properties: MappedRe
 
 /**
  * Determines if the provided search results has any object that matches the provided mapped object.
- * All properties have to be the same for the function to return true.
+ * The new object should have the same number of properties and all properties should be the same for the function to return true.
  * @param mappedObject An object based on the mapping
  * @param searchResults Search results returned from the server
  */
 function hasObject(mappedObject: MappedRecord, searchResults: ObjectData[]): boolean {
-  return searchResults.some((existingObject) =>
-    Object.entries(existingObject.record.data).every(
-      ([property, value]) => mappedObject[property] === value,
-    ),
+  return searchResults.some(
+    (existingObject) =>
+      Object.entries(existingObject.record.data).length === Object.keys(mappedObject).length &&
+      Object.entries(existingObject.record.data).every(
+        ([property, value]) => mappedObject[property] === value,
+      ),
   )
 }
 

--- a/boom-app/src/views/PreView.vue
+++ b/boom-app/src/views/PreView.vue
@@ -223,10 +223,10 @@ function postSingleObject(typeUrl: string, version: number, properties: MappedRe
  * @param searchResults Search results returned from the server
  */
 function hasObject(mappedObject: MappedRecord, searchResults: ObjectData[]): boolean {
-  return searchResults.some(existingObject =>
-    Object.entries(existingObject.record.data).every(([property, value]) =>
-      mappedObject[property] === value
-    )
+  return searchResults.some((existingObject) =>
+    Object.entries(existingObject.record.data).every(
+      ([property, value]) => mappedObject[property] === value,
+    ),
   )
 }
 
@@ -330,10 +330,10 @@ async function postRequest<T>(body: object, urlExtension = ''): Promise<T> {
       <!-- Preview box -->
       <div v-if="!isEntryDone && !errorMessage" class="flex column box">
         <h2>Preview of a new object</h2>
-        <caption>
+        <p>
           Here you see a preview of how the first row of the CSV data will be inserted as a new
           object:
-        </caption>
+        </p>
         <h3>New object</h3>
         <ul>
           <li


### PR DESCRIPTION
## Projecttracking Context

### Related issue

Closes [29](https://github.com/ICATT-Menselijk-Digitaal/boom/issues/29)

## PR Description

### Overview of Changes

- Added checking of `next` value in response. If it is valid, the value is used to fetch the next page of the objecttypes.
- Changed search function to simplify the implementation and remove bugs.

### Details and/or extra information

#### PreView.vue

- Search function was improved by using `.some` and `.every` to simplify the implementation.
- A check was added to see if the new object and existing object have the same number of properties. This removed a bug that did not take into account the number of properties to be checked. 